### PR TITLE
fix: use gather for get_proj_info

### DIFF
--- a/lua/neotest-vstest/dotnet_utils.lua
+++ b/lua/neotest-vstest/dotnet_utils.lua
@@ -284,23 +284,21 @@ function dotnet_utils.get_solution_projects(solution_path)
 
   local solution_dir = vim.fs.dirname(solution_path)
 
-  local projects = {}
+  local projects = dotnet_utils.projects(solution_path)
 
-  if solution_path then
-    projects = dotnet_utils.projects(solution_path)
-  else
-    logger.info("found no solution file in " .. solution_path)
-    projects = vim.fs.find(function(name, _)
-      return name:match("%.[cf]sproj$")
-    end, { upward = false, type = "file", path = solution_path })
-  end
-
-  local test_projects = {}
+  local _test_projects = {}
 
   for _, project in ipairs(projects) do
-    local project_info = dotnet_utils.get_proj_info(project)
-    if project_info and project_info.is_test_project then
-      test_projects[#test_projects + 1] = project_info
+    _test_projects[#_test_projects + 1] = function()
+      return dotnet_utils.get_proj_info(project)
+    end
+  end
+
+  local all_projects_info = nio.gather(_test_projects)
+  local test_projects = {}
+  for _, project in ipairs(all_projects_info) do
+    if project and project.is_test_project then
+      test_projects[#test_projects + 1] = project
     end
   end
 


### PR DESCRIPTION
This seems to speed things up for me pretty dramatically. Some very naive timing just with my stopwatch on my phone it goes like this:

main:
- Test output starting to show: 20 seconds
- Finished: 34 seconds

This branch:
- Test output starting to show: 6 seconds
- Finished: 20 seconds

So, in my project it reduces the time down from 20 to 6 seconds.

The last 14 seconds is building the projects, and finding the tests.

From my initial testing which I also mentioned in the issue, it seems like building is ~12 of these 14 seconds