### PR TITLE
feat: remove build logic from test clients

### DIFF
--- a/lua/neotest-vstest/client.lua
+++ b/lua/neotest-vstest/client.lua
@@ -3,6 +3,80 @@ local logger = require("neotest.logging")
 local mtp_client = require("neotest-vstest.mtp")
 local vstest_client = require("neotest-vstest.vstest")
 local dotnet_utils = require("neotest-vstest.dotnet_utils")
+local files = require("neotest-vstest.files")
+
+--- @class neotest-vstest.wrapper-client: neotest-vstest.Client
+--- @field project DotnetProjectInfo
+--- @field discover_tests_for_path fun(self: neotest-vstest.Client, path: string): table<string, table<string, neotest-vstest.TestCase>>
+--- @field private sub_client neotest-vstest.Client
+--- @field private semaphore nio.control.Semaphore
+--- @field private had_first_discovery boolean
+local TestClient = {}
+TestClient.__index = TestClient
+
+function TestClient:new(project, sub_client)
+  local client = {
+    sub_client = sub_client,
+    project = project,
+    semaphore = nio.control.semaphore(1),
+    last_discovered = nil,
+  }
+
+  setmetatable(client, self)
+  return client
+end
+
+function TestClient:discover_tests(path)
+  self.semaphore.acquire()
+
+  local last_modified
+
+  local test_cases = self.sub_client.test_cases or {}
+
+  if self.last_discovered == nil then
+    last_modified = dotnet_utils.get_project_last_modified(self.project)
+    self.last_discovered = last_modified or 0
+    test_cases = self.sub_client:discover_tests()
+  else
+    if path then
+      last_modified = files.get_path_last_modified(path)
+    else
+      last_modified = dotnet_utils.get_project_last_modified(self.project)
+    end
+
+    if last_modified and last_modified > self.last_discovered then
+      logger.debug(
+        "neotest-vstest: Discovering tests: "
+          .. " last modified at "
+          .. last_modified
+          .. " last discovered at "
+          .. self.last_discovered
+      )
+      dotnet_utils.build_project(self.project)
+      last_modified = dotnet_utils.get_project_last_modified(self.project)
+      self.last_discovered = last_modified or 0
+      test_cases = self.sub_client:discover_tests()
+    end
+  end
+
+  self.semaphore.release()
+
+  return test_cases
+end
+
+function TestClient:discover_tests_for_path(path)
+  local tests = self:discover_tests(path)
+  path = vim.fs.normalize(path)
+  return tests[path]
+end
+
+function TestClient:run_tests(ids)
+  return self.sub_client:run_tests(ids)
+end
+
+function TestClient:debug_tests(ids)
+  return self.sub_client:debug_tests(ids)
+end
 
 local client_discovery = {}
 
@@ -67,6 +141,8 @@ function client_discovery.get_client_for_project(project, solution)
     clients[project.proj_file] = false
     return
   end
+
+  client = TestClient:new(project, client)
 
   clients[project.proj_file] = client
   return client

--- a/lua/neotest-vstest/init.lua
+++ b/lua/neotest-vstest/init.lua
@@ -57,14 +57,14 @@ local function create_adapter(config)
 
     solution = config.solution_selector and config.solution_selector(solutions) or nil
 
-    if solution then
-      solution_dir = vim.fs.dirname(solution)
-      solution_projects = dotnet_utils.projects(solution)
-      return solution_dir
-    else
-      if #solutions > 0 then
-        local solution_dir_future = nio.control.future()
+    if solution or #solutions > 0 then
+      local solution_dir_future = nio.control.future()
 
+      if solution then
+        solution_dir = vim.fs.dirname(solution)
+        solution_projects = dotnet_utils.projects(solution)
+        solution_dir_future.set(solution_dir)
+      else
         if #solutions == 1 then
           solution = solutions[1]
           solution_dir = vim.fs.dirname(solution)
@@ -90,6 +90,7 @@ local function create_adapter(config)
         if solution_dir_future.wait() and solution then
           logger.info(string.format("neotest-vstest: found solution file %s", solution))
           solution_projects = dotnet_utils.projects(solution)
+          dotnet_utils.build_path(solution)
           return solution_dir
         end
       end

--- a/lua/neotest-vstest/mtp/init.lua
+++ b/lua/neotest-vstest/mtp/init.lua
@@ -1,35 +1,21 @@
-local nio = require("nio")
 local logger = require("neotest.logging")
-local dotnet_utils = require("neotest-vstest.dotnet_utils")
-local files = require("neotest-vstest.files")
 local mtp_client = require("neotest-vstest.mtp.client")
 
 --- @class neotest-vstest.mtp-client: neotest-vstest.Client
 --- @field project DotnetProjectInfo
---- @field semaphore nio.control.Semaphore
---- @field last_discovered integer
+--- @field private last_discovered integer
 local Client = {}
 Client.__index = Client
 
-local clients = {}
-
 ---@param project DotnetProjectInfo
 function Client:new(project)
-  if clients[project.proj_file] then
-    logger.info("neotest-vstest: Reusing existing (MTP) client for: " .. vim.inspect(project))
-    return clients[project.proj_file]
-  end
-
   logger.info("neotest-vstest: Creating new (MTP) client for: " .. vim.inspect(project))
   local client = {
     project = project,
     test_cases = {},
     last_discovered = 0,
-    semaphore = nio.control.semaphore(1),
   }
   setmetatable(client, self)
-
-  clients[project.proj_file] = client
 
   return client
 end
@@ -61,40 +47,11 @@ local function map_test_cases(project, test_nodes)
   return test_cases
 end
 
-function Client:discover_tests(path)
-  self.semaphore.acquire()
-
-  local last_modified
-  if path then
-    last_modified = files.get_path_last_modified(path)
-  else
-    last_modified = dotnet_utils.get_project_last_modified(self.project)
-  end
-  if last_modified and last_modified > self.last_discovered then
-    logger.debug(
-      "neotest-vstest: Discovering tests: "
-        .. " last modified at "
-        .. last_modified
-        .. " last discovered at "
-        .. self.last_discovered
-    )
-    dotnet_utils.build_project(self.project)
-    last_modified = dotnet_utils.get_project_last_modified(self.project)
-    self.last_discovered = last_modified or 0
-    self.test_nodes = mtp_client.discovery_tests(self.project.dll_file)
-    self.test_cases = map_test_cases(self.project, self.test_nodes)
-    logger.debug(self.test_cases)
-  end
-
-  self.semaphore.release()
+function Client:discover_tests()
+  self.test_nodes = mtp_client.discovery_tests(self.project.dll_file)
+  self.test_cases = map_test_cases(self.project, self.test_nodes)
 
   return self.test_cases
-end
-
-function Client:discover_tests_for_path(path)
-  self:discover_tests(path)
-  path = vim.fs.normalize(path)
-  return self.test_cases[path]
 end
 
 ---@async

--- a/lua/neotest-vstest/types.lua
+++ b/lua/neotest-vstest/types.lua
@@ -19,7 +19,7 @@
 ---@field stop fun()
 
 ---@class neotest-vstest.Client
+---@field test_cases table<string, table<string, neotest-vstest.TestCase>>
+---@field discover_tests fun(self: neotest-vstest.Client): table<string, table<string, neotest-vstest.TestCase>>
 ---@field run_tests fun(self: neotest-vstest.Client, ids: string|string[]): neotest-vstest.Client.RunResult
----@field discover_tests fun(self: neotest-vstest.Client, path?: string): table<string, table<string, neotest-vstest.TestCase>>
----@field discover_tests_for_path fun(self: neotest-vstest.Client, path: string): table<string, table<string, neotest-vstest.TestCase>>
 ---@field debug_tests fun(self: neotest-vstest.Client, ids: string|string[]): neotest-vstest.Client.DebugResult


### PR DESCRIPTION
Refactors the test clients so its easier to determine if a rebuild should happen.
Mostly, this enables us to run test discovery without triggering a project build on initial discovery.

In this case I've opted to build the entire solution on startup.

I don't know if this have any improvements for you @seblyng compared to building the projects individually?