### PR TITLE
Fixes an issue with the dotnet executable not being killed

### DIFF
--- a/lua/neotest-vstest/mtp/client.lua
+++ b/lua/neotest-vstest/mtp/client.lua
@@ -107,7 +107,9 @@ function M.create_client(dll_path, on_update, on_log, mtp_env)
       cmd = vim.lsp.rpc.connect(server:getsockname().ip, server:getsockname().port),
       root_dir = vim.fs.dirname(dll_path),
       on_exit = function()
-        logger.debug("neotest-vstest: MTP process shutdown triggered from client with PID: " .. mtp_process.pid)
+        logger.debug(
+          "neotest-vstest: MTP process shutdown triggered from client with PID: " .. mtp_process.pid
+        )
         server:shutdown()
         mtp_process:kill(9)
       end,
@@ -206,9 +208,9 @@ local function parseTestResult(test)
   return {
     status = outcome,
     short = test.node["standardOutput"]
-        or test.node["error.message"]
-        or test.node["execution-state"]
-        or default_short_message,
+      or test.node["error.message"]
+      or test.node["execution-state"]
+      or default_short_message,
     errors = errors,
   }
 end

--- a/lua/neotest-vstest/mtp/client.lua
+++ b/lua/neotest-vstest/mtp/client.lua
@@ -137,7 +137,7 @@ function M.create_client(dll_path, on_update, on_log, mtp_env)
     client_future.set(client)
   end)
 
-  return client_future, mtp_process_pid
+  return client_future, mtp_process.pid
 end
 
 ---@async

--- a/lua/neotest-vstest/mtp/client.lua
+++ b/lua/neotest-vstest/mtp/client.lua
@@ -33,7 +33,9 @@ local function start_server(dll_path, mtp_env)
       logger.debug("neotest-vstest: Accepted connection from mtp")
       mtp_client = client
       client:read_start(function(err, data)
-        -- assert(not err, err)
+        if err then
+          logger.warn("neotest-vstest: " .. err)
+        end
         if data then
           logger.trace("neotest-vstest: Received data from mtp with pid: " .. data)
           lsp_client:write(data)
@@ -155,6 +157,7 @@ function M.discovery_tests(dll_path)
 
   local client_future = M.create_client(dll_path, on_update, function() end)
 
+  --@type vim.lsp.Client
   local client = client_future.wait()
 
   nio.scheduler()
@@ -163,7 +166,7 @@ function M.discovery_tests(dll_path)
   local run_id = uuid()
   client:request_sync("testing/discoverTests", {
     runId = run_id,
-  })
+  }, 30000)
 
   logger.debug("neotest-vstest: Discovered test results: " .. vim.inspect(tests))
 

--- a/lua/neotest-vstest/vstest/cli_wrapper.lua
+++ b/lua/neotest-vstest/vstest/cli_wrapper.lua
@@ -111,7 +111,7 @@ function M.create_test_runner(project)
       process:write(content .. "\n")
     end,
     stop = function()
-      process:kill(0)
+      process:kill(9)
     end,
   }
 end


### PR DESCRIPTION
I was running into an issue where the dotnet process was not being killed properly. This is an issue on Windows because if the process stays around, the dll is locked to that process causing every subsequent rebuilding to fail. 

I think this PR might need a little work as I had to remove an assertion ensuring no errors in the client:read_start method.