### PR TITLE
Using the short name for the display name

### DIFF
--- a/lua/neotest-vstest/mtp/init.lua
+++ b/lua/neotest-vstest/mtp/init.lua
@@ -34,7 +34,7 @@ local function map_test_cases(project, test_nodes)
       test_cases[file] = vim.tbl_extend("force", existing, {
         [node.uid] = {
           CodeFilePath = location,
-          DisplayName = node["display-name"],
+          DisplayName = string.gsub(node["display-name"], "[^(]+%.", "", 1),
           LineNumber = line_number,
           FullyQualifiedName = fully_qualified_name,
         },


### PR DESCRIPTION
This was implemented for vstest but not mtp so I ported over the `string.gsub` line that was used to get the short name. I don't know if we need to check beforehand if the display name contains the fully qualified name like before