### PR TITLE
fix(discovery): test if file contains test

### DIFF
--- a/lua/neotest-vstest/init.lua
+++ b/lua/neotest-vstest/init.lua
@@ -129,6 +129,18 @@ local function create_adapter(config)
       return false
     end
 
+    local tests_in_file = client:discover_tests_for_path(file_path)
+
+    if not tests_in_file or next(tests_in_file) == nil then
+      logger.debug(
+        string.format(
+          "neotest-vstest: marking file as non-test file since no tests was found in file %s",
+          file_path
+        )
+      )
+      return false
+    end
+
     return true
   end
 


### PR DESCRIPTION
The method to determine if the file is a test file did not take into account that it actually had tests for the file. It just checked that the file is from a project with a client.
There may be files that are not test files within the project.