### PR TITLE
fix: "Couldn't find positions in path"

### DIFF
--- a/scripts/run_tests.fsx
+++ b/scripts/run_tests.fsx
@@ -118,7 +118,9 @@ module TestDiscovery =
 
                 Console.WriteLine($"Discovered tests for: {testFiles}")
 
-                using (new StreamWriter(outputFile, append = false)) (fun testsWriter ->
+                do
+                    use testsWriter = new StreamWriter(outputFile, append = false)
+
                     discoveredTests.Values
                     |> Seq.sortBy (fun testCase -> testCase.CodeFilePath, testCase.LineNumber)
                     |> Seq.map (fun testCase ->
@@ -129,7 +131,7 @@ module TestDiscovery =
                               DisplayName = testCase.DisplayName
                               LineNumber = testCase.LineNumber
                               FullyQualifiedName = testCase.FullyQualifiedName } })
-                    |> Seq.iter (JsonConvert.SerializeObject >> testsWriter.WriteLine))
+                    |> Seq.iter (JsonConvert.SerializeObject >> testsWriter.WriteLine)
 
                 use waitFileWriter = new StreamWriter(waitFile, append = false)
                 waitFileWriter.WriteLine("1")
@@ -303,7 +305,12 @@ module TestDiscovery =
                     let testCases = getTestCases args.Ids
 
                     use testHandler =
-                        new PlaygroundTestRunHandler(args.StreamPath, args.OutputPath, args.ProcessOutput, args.OutputDirPath)
+                        new PlaygroundTestRunHandler(
+                            args.StreamPath,
+                            args.OutputPath,
+                            args.ProcessOutput,
+                            args.OutputDirPath
+                        )
                     // spawn as task to allow running concurrent tests
                     do! r.RunTestsAsync(testCases, sourceSettings, testHandler)
                     Console.WriteLine($"Done running tests for ids: ")
@@ -319,7 +326,12 @@ module TestDiscovery =
                     let testCases = getTestCases args.Ids
 
                     use testHandler =
-                        new PlaygroundTestRunHandler(args.StreamPath, args.OutputPath, args.ProcessOutput, args.OutputDirPath)
+                        new PlaygroundTestRunHandler(
+                            args.StreamPath,
+                            args.OutputPath,
+                            args.ProcessOutput,
+                            args.OutputDirPath
+                        )
 
                     let debugLauncher = DebugLauncher(args.PidPath, args.AttachedPath)
                     Console.WriteLine($"Starting {Seq.length testCases} tests in debug-mode")


### PR DESCRIPTION
Quite often I get errors like this one:

    ERROR | 2025-10-18T18:40:14Z+0100 | ...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:309 | Couldn't find positions in path <redacted> ...tart/neotest-vstest/lua/neotest-vstest/vstest/client.lua:44: Expected value but found unexpected end of string at character 292
    stack traceback:
            [C]: in function 'decode'
            ...tart/neotest-vstest/lua/neotest-vstest/vstest/client.lua:44: in function 'discover_tests_in_project'
            .../start/neotest-vstest/lua/neotest-vstest/vstest/init.lua:34: in function 'discover_tests'
            ...undle/start/neotest-vstest/lua/neotest-vstest/client.lua:39: in function 'discover_tests'
            .../bundle/start/neotest-vstest/lua/neotest-vstest/init.lua:299: in function 'discover_positions'
            ...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:300: in function <...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:264>
            [C]: in function 'xpcall'
            ...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:264: in function '_update_positions'
            ...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:317: in function <...te/pack/bundle/start/neotest/lua/neotest/client/init.lua:315>

I think that's because the test discovery doesn't flush the `outputFile` before signalling back by writing "1" to the `waitFile`. Using `using` to dispose of the `outputFile` `StreamWriter` seems to fix this — I don't get those errors any more.
