### PR TITLE
chore: changed hardcoded SIGKILL number to enum

### DIFF
--- a/lua/neotest-vstest/mtp/client.lua
+++ b/lua/neotest-vstest/mtp/client.lua
@@ -111,7 +111,7 @@ function M.create_client(dll_path, on_update, on_log, mtp_env)
           "neotest-vstest: MTP process shutdown triggered from client with PID: " .. mtp_process.pid
         )
         server:shutdown()
-        mtp_process:kill(9)
+        mtp_process:kill(vim.uv.constants.SIGKILL)
       end,
       before_init = function(params)
         params.processId = vim.fn.getpid()


### PR DESCRIPTION
Just a small change. Stumbled across this argument to kill and did not know what '9' meant. So thought the uv.constants may be better to communicate the intent.