### PR TITLE
feat(build): add support for additional dotnet build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 </p>
 
 <p align="center">
-  <img 
-    width="923" 
-    alt="test discovery sample" 
+  <img
+    width="923"
+    alt="test discovery sample"
     src="https://github.com/user-attachments/assets/7e297d7a-f06d-44a9-adef-92131185e8ca" />
 </p>
 
@@ -79,6 +79,10 @@ require("neotest").setup({
       solution_selector = function(solutions)
         return nil -- return the solution you want to use or nil to let the adapter choose.
       end
+      build_opts = {
+          -- Arguments that will be added to all `dotnet build` and `dotnet msbuild` commands
+          additional_args = {}
+      }
     })
   }
 })

--- a/lua/neotest-vstest/init.lua
+++ b/lua/neotest-vstest/init.lua
@@ -1,12 +1,15 @@
 ---@class neotest-vstest.Config
 ---@field sdk_path? string path to dotnet sdk. Example: /usr/local/share/dotnet/sdk/9.0.101/
+---@field build_opts? BuildOpts
 ---@field dap_settings? dap.Configuration dap settings for debugging
 ---@field solution_selector? fun(solutions: string[]): string|nil
 
 ---@param config? neotest-vstest.Config
 ---@return neotest.Adapter
 local function create_adapter(config)
+  local dotnet_utils = require("neotest-vstest.dotnet_utils")
   config = config or {}
+  dotnet_utils.add_opts(config.build_opts or {})
 
   --- @type dap.Configuration
   local dap_settings = vim.tbl_extend("force", {


### PR DESCRIPTION
Ive gone with the approach of having a state in dotnet_utils in order to avoid having to send the build arguments all over the code.

I first tried to add build args to the spec.context etc. but it quickly became awkward to throw around everywhere.

Implements: #45