### PR TITLE
Add support for .runsettings with vstest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,6 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
+continuation_indent = 2
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/README.md
+++ b/README.md
@@ -73,16 +73,24 @@ require("neotest").setup({
       -- table is passed directly to DAP when debugging tests.
       dap_settings = {
         type = "netcoredbg",
-      }
+      },
       -- If multiple solutions exists the adapter will ask you to choose one.
       -- If you have a different heuristic for choosing a solution you can provide a function here.
       solution_selector = function(solutions)
         return nil -- return the solution you want to use or nil to let the adapter choose.
-      end
+      end,
+      -- If multiple .runsettings/testconfig.json files are present in the test project directory
+      -- you will be given the choice of file to use when setting up the adapter.
+      -- Or you can provide a function here
+      -- default nil to select from all files in project directory 
+      settings_selector = function(project_dir)
+        return nil -- return the .runsettings/testconfig.json file you want to use or let the adapter choose
+      end,
       build_opts = {
           -- Arguments that will be added to all `dotnet build` and `dotnet msbuild` commands
           additional_args = {}
-      }
+      },
+      timeout_ms = 30 * 5 * 1000 -- number of milliseconds to wait before timeout while communicating with adapter client
     })
   }
 })

--- a/lua/neotest-vstest/init.lua
+++ b/lua/neotest-vstest/init.lua
@@ -3,6 +3,8 @@
 ---@field build_opts? BuildOpts
 ---@field dap_settings? dap.Configuration dap settings for debugging
 ---@field solution_selector? fun(solutions: string[]): string|nil
+---@field settings_selector? fun(project_dir: string): string|nil function to find the .runsettings/testconfig.json in the project dir
+---@field timeout_ms? number milliseconds to wait before timing out connection with test runner
 
 ---@param config? neotest-vstest.Config
 ---@return neotest.Adapter
@@ -559,6 +561,7 @@ local function create_adapter(config)
 
     return results
   end
+
   return DotnetNeotestAdapter
 end
 
@@ -567,6 +570,8 @@ local DotnetNeotestAdapter = create_adapter()
 ---@param opts neotest-vstest.Config
 local function apply_user_settings(_, opts)
   vim.g.neotest_vstest_sdk_path = opts and opts.sdk_path or nil
+  vim.g.neotest_vstest_find_settings = opts and opts.settings_selector or nil
+  vim.g.neotest_vstest_timeout_ms = opts and opts.timeout_ms or 5 * 30 * 1000
   return create_adapter(opts)
 end
 


### PR DESCRIPTION
Edit: This PR adds support for (automatically) selecting a .runsettings file that is located in the test project directory. If more than one .runsettings file is present, the user is given a choice via `vim.ui.select`. The user can also specify a custom .runsettings selector function via the plugin configuration. I have also added a configuration option for the vstest client communication timeout.

Notably missing from this PR are automated tests, and MTP/`.testconfig.json` support. My current platform (linux/ubuntu) does not yet have an easy to obtain release of .NET10, but I will open a new PR to add MTP support once I can easily test it locally.

<del>WIP PR, looking for feedback.

<del>MTP has abandoned the `.runsettings` format in favour of `testconfig.json`, so we will need to add client specific support for each.