### PR TITLE
use notify during test discovery

### DIFF
--- a/lua/neotest-vstest/init.lua
+++ b/lua/neotest-vstest/init.lua
@@ -103,8 +103,16 @@ local function create_adapter()
       end
 
       if solution_future.wait() and solution then
+        local progress = require("neotest-vstest.progress")
+        local sln_name = vim.fs.basename(solution)
+
+        progress.begin("Building " .. sln_name .. "…")
         dotnet_utils.build_path(solution)
+
+        progress.update("Resolving projects in " .. sln_name .. "…")
         dotnet_utils.get_solution_info(solution)
+        progress.finish()
+
         solution = string.gsub(solution, "/", lib.files.sep)
         solution_dir = string.gsub(vim.fs.dirname(solution), "/", lib.files.sep)
         logger.info(string.format("neotest-vstest: found solution dir %s", solution_dir))

--- a/lua/neotest-vstest/progress.lua
+++ b/lua/neotest-vstest/progress.lua
@@ -1,0 +1,38 @@
+local M = {}
+
+local active = false
+local opts_sticky = { title = "neotest-vstest", id = "neotest-vstest-progress", timeout = false }
+local opts_dismiss = { title = "neotest-vstest", id = "neotest-vstest-progress" }
+
+---@param msg string
+---@param level integer
+---@param opts table
+local function notify(msg, level, opts)
+  vim.schedule(function()
+    vim.notify(msg, level, opts)
+  end)
+end
+
+---@param msg string
+function M.begin(msg)
+  if not active then
+    active = true
+    notify(msg, vim.log.levels.INFO, opts_sticky)
+  end
+end
+
+---@param msg string
+function M.update(msg)
+  if active then
+    notify(msg, vim.log.levels.INFO, opts_sticky)
+  end
+end
+
+function M.finish()
+  if active then
+    active = false
+    notify("✓ Test discovery complete", vim.log.levels.INFO, opts_dismiss)
+  end
+end
+
+return M


### PR DESCRIPTION
- show intermediate messages when discovering test
- provides better feedback on bigger projects that build longer
- can work with notification plugins with additional parameters
- additional parameters are silently ignored